### PR TITLE
fix:更新plan时数据为空的问题

### DIFF
--- a/src/page/plan/planCreate.vue
+++ b/src/page/plan/planCreate.vue
@@ -594,8 +594,7 @@ const router = useRouter();
 const stepContainerRef = ref(null);
 
 const backToPlan = () => {
-  clusterStore.configFormRef.resetFields();
-  clusterStore.configInfo.nodes = [];
+  clusterStore.resetViewData();
   router.replace({
     name: 'Plan',
   });

--- a/src/page/plan/planCreate.vue
+++ b/src/page/plan/planCreate.vue
@@ -579,7 +579,7 @@
   </div>
 </template>
 <script setup>
-import { reactive, getCurrentInstance, ref, onMounted } from 'vue';
+import { reactive, getCurrentInstance, ref, onMounted, onBeforeUnmount } from 'vue';
 import useClusterStore from '@/stores/useCluster';
 import pixiuDialog from '@/components/pixiuDialog/index.vue';
 import { formatterTime, formatterNodeAuthType, formatterNodeRole } from '@/utils/formatter';
@@ -611,6 +611,13 @@ const createPlan = async () => {
     });
   }
 };
+
+onBeforeUnmount(() => {
+  console.log(123);
+  if (clusterStore) {
+    clusterStore.resetViewData();
+  }
+});
 
 /* const goToStep = (index) => {
   clusterStore.active = index - 1;

--- a/src/stores/useCluster.js
+++ b/src/stores/useCluster.js
@@ -349,7 +349,7 @@ const useClusterStore = defineStore('cluster', () => {
     });
   };
 
-  const goBackToPlan = () => {
+  const resetViewData = () => {
     configFormRef.value.resetFields();
     configInfo.nodes = [];
     planId.value = undefined;

--- a/src/stores/useCluster.js
+++ b/src/stores/useCluster.js
@@ -3,6 +3,7 @@ import { ref, reactive, toRaw, watch } from 'vue';
 import { ElMessage } from 'element-plus';
 import { createPlan, updatePlan, getPlanResources } from '@/services/plan/planService';
 import { deepMerge, parseNetwork } from '@/utils/utils';
+// import { router } from '@/router';
 
 const useClusterStore = defineStore('cluster', () => {
   const active = ref(0);
@@ -348,6 +349,12 @@ const useClusterStore = defineStore('cluster', () => {
     });
   };
 
+  const goBackToPlan = () => {
+    configFormRef.value.resetFields();
+    configInfo.nodes = [];
+    planId.value = undefined;
+  };
+
   const handleDeleteDialog = (scope) => {
     deleteDialog.close = true;
     deleteDialog.index = scope.$index;
@@ -427,6 +434,7 @@ const useClusterStore = defineStore('cluster', () => {
     confirmDelete,
     cancel,
     createOrEditPlan,
+    resetViewData,
   };
 });
 


### PR DESCRIPTION
原因：因为在触发更新的时候通过的是监听planId的变化来操作的，离开页面时虽然清空了数据却没有清空planId导致二次进入相同id的数据时，没有重新发起请求获取数据